### PR TITLE
Updates to README and basic support for level tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # SpaceTracker
 
-Tracks the changes in a Revit project and saves the general structure of it in a realtional SQLite-Database and a graph-based Neo4j-Database to illustrate differences between those two types of DBs.
+Tracks the changes in a Revit project and saves the general structure of it in a relational SQLite-Database and a graph-based Neo4j-Database to illustrate differences between those two types of DBs.
 
 ## Requirements
 
-* Revit 2022
+* Revit 2022 
+* RevitAPI 2022 Development Environment
+* Sqlite3
+* Neo4j
 
 ## Installation
 
 1. Fork & clone the repo
 2. add the `SpaceTracker/SpaceTracker.addin` file to the addins folder located at `C:\Users\$USERNAME\AppData\Roaming\Autodesk\Revit\Addins\2022`
 3. Make sure `Revit.exe` is set as an external program in the debug menu in Visual Studio (Poject --> Properties --> Debug)
-4. Run, and an instance of Revit will open automatically
+4. Create a local SQlite DB: `C:\sqlite_tmp\RoomWallWindow_sample.db` with the necessary tables
+5. Create a local neo4j DB with credentials `neo4j` and `password`
+6. Run, and an instance of Revit will open automatically


### PR DESCRIPTION
Introduces Level tracking. 
SQL: New tables `Level` and `contains`. The latter contains the `LevelIds` and all `ElementIds` of elements within a Level
Neo4j: For each level, a Node with label `Level` is created. Has `CONTAINS` relationships with all nodes representing elements within that level

Small Updates to README.md